### PR TITLE
Memory optimise

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "2.4"
 services:
   bot:
     image: f1-bot:latest

--- a/f1/api/stats.py
+++ b/f1/api/stats.py
@@ -613,7 +613,7 @@ def laptime_table(df: pd.DataFrame) -> tuple[Figure, Axes]:
     size = (6, (df["Driver"].size / 3.333) + 1)
     table = plot_table(df, col_defs, "Rank", figsize=size)
     table.rows[0].set_hatch("//").set_facecolor("#b138dd").set_alpha(0.35)
-    table.columns["ST"].cells[df["ST"].idxmax() - 1].text.set_color("#b138dd")
+    table.columns["ST"].cells[df["ST"].idxmax()].text.set_color("#b138dd")
 
     return table.figure, table.ax
 

--- a/f1/api/stats.py
+++ b/f1/api/stats.py
@@ -98,7 +98,9 @@ async def load_session(event: Event, name: str, **kwargs) -> Session:
     except Exception:
         raise MissingDataError("Unable to get session data, check the round and year is correct.")
 
-    gc.collect()
+    finally:
+        gc.collect()
+
     return session
 
 
@@ -532,6 +534,7 @@ def results_table(results: pd.DataFrame, name: str) -> tuple[Figure, Axes]:
         ]
 
     table = plot_table(df=results, col_defs=col_defs, idx=idx, figsize=size)
+    del results
 
     # Highlight DNFs in race
     if get_session_type(name) == "R":
@@ -553,6 +556,7 @@ def pitstops_table(results: pd.DataFrame) -> tuple[Figure, Axes]:
     # Different sizes depending on amound of data shown with filters
     size = (5, (results["Code"].size / 3.333) + 1)
     table = plot_table(results, col_defs, "Code", figsize=size)
+    del results
 
     return table.figure, table.ax
 
@@ -614,6 +618,7 @@ def laptime_table(df: pd.DataFrame) -> tuple[Figure, Axes]:
     table = plot_table(df, col_defs, "Rank", figsize=size)
     table.rows[0].set_hatch("//").set_facecolor("#b138dd").set_alpha(0.35)
     table.columns["ST"].cells[df["ST"].idxmax()].text.set_color("#b138dd")
+    del df
 
     return table.figure, table.ax
 
@@ -637,5 +642,6 @@ def sectors_table(df: pd.DataFrame) -> tuple[Figure, Axes]:
     table.columns["S2"].cells[df["Sector2Time"].idxmin()].text.set_color("#b138dd")
     table.columns["S3"].cells[df["Sector3Time"].idxmin()].text.set_color("#b138dd")
     table.columns["ST"].cells[df["ST"].idxmax()].text.set_color("#b138dd")
+    del df
 
     return table.figure, table.ax

--- a/f1/cogs/plot.py
+++ b/f1/cogs/plot.py
@@ -8,9 +8,9 @@ import pandas as pd
 import seaborn as sns
 from discord.commands import ApplicationContext
 from discord.ext import commands
-from matplotlib import pyplot as plt
 from matplotlib.collections import LineCollection
 from matplotlib.colors import ListedColormap, Normalize
+from matplotlib.figure import Figure
 
 from f1 import options, utils
 from f1.api import ergast, stats
@@ -50,7 +50,8 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         # Get driver labels
         drivers = [session.get_driver(d)["Abbreviation"] for d in session.drivers]
 
-        fig, ax = plt.subplots(figsize=(6, 10), dpi=DPI)
+        fig = Figure(figsize=(6, 10), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot()
 
         for driver in drivers:
             stints = data.loc[data["Driver"] == driver]
@@ -59,7 +60,7 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
             # Iterate each stint per driver
             for r in stints.itertuples():
                 # Plot the stint compound and laps to the bar stack
-                plt.barh(
+                ax.barh(
                     y=driver,
                     width=r.Laps,
                     height=0.5,
@@ -79,15 +80,16 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
 
         # Presentation
         yr, rd = event['EventDate'].year, event['RoundNumber']
-        plt.title(f"Race Tyre Stints - \n {event['EventName']} ({yr})")
-        plt.xlabel("Lap Number"),
-        plt.grid(False)
-        plt.legend(handles=patches, loc="upper center", ncols=len(patches))
+        ax.set_title(f"Race Tyre Stints - \n {event['EventName']} ({yr})")
+        ax.set_xlabel("Lap Number"),
+        ax.grid(False)
+        ax.legend(handles=patches, loc="upper center", ncols=len(patches))
         ax.invert_yaxis()
         ax.spines["top"].set_visible(False)
         ax.spines["right"].set_visible(False)
         ax.spines["left"].set_visible(False)
-        plt.tight_layout()
+
+        del event, session, data
 
         # Get plot image
         f = utils.plot_to_file(fig, f"plot_stints-{yr}-{rd}")
@@ -103,7 +105,8 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         ev = await stats.to_event(year, round)
         session = await stats.load_session(ev, "R", laps=True)
 
-        fig, ax = plt.subplots(figsize=(8.5, 5.46), dpi=DPI)
+        fig = Figure(figsize=(8.5, 5.46), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot()
 
         # Plot the drivers position per lap
         for d in session.drivers:
@@ -113,14 +116,13 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
                     color=utils.get_driver_or_team_color(id, session, api_only=True))
 
         # Presentation
-        plt.title(f"Race Position - {ev['EventName']} ({ev['EventDate'].year})")
-        plt.xlabel("Lap")
-        plt.ylabel("Position")
-        plt.yticks(np.arange(1, len(session.drivers) + 1))
-        plt.tick_params(axis="y", right=True, left=True, labelleft=True, labelright=False)
+        ax.set_title(f"Race Position - {ev['EventName']} ({ev['EventDate'].year})")
+        ax.set_xlabel("Lap")
+        ax.set_ylabel("Position")
+        ax.set_yticks(np.arange(1, len(session.drivers) + 1))
+        ax.tick_params(axis="y", right=True, left=True, labelleft=True, labelright=False)
         ax.invert_yaxis()
         ax.legend(bbox_to_anchor=(1.01, 1.0))
-        plt.tight_layout()
 
         # Create image
         f = utils.plot_to_file(fig, f"plot_pos-{ev['EventDate'].year}-{ev['RoundNumber']}")
@@ -144,7 +146,8 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
                for d in fastest_laps["Driver"].values]
 
         # Plotting
-        fig, ax = plt.subplots(figsize=(8, 6.75), dpi=DPI)
+        fig = Figure(figsize=(8, 6.75), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot()
         bars = ax.barh(fastest_laps["Driver"], fastest_laps["Delta"], color=clr)
 
         # Place a label next to each bar showing the delta in seconds
@@ -162,10 +165,9 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
 
         ax.invert_yaxis()
         ax.grid(True, which="major", axis="x", zorder=0, alpha=0.2)
-        plt.xlabel("Time Delta")
-        plt.title(f"{s.name} - {ev['EventName']} ({ev['EventDate'].year})")
-        plt.suptitle(f"Fastest: {top['LapTime']} ({top['Driver']})")
-        plt.tight_layout()
+        ax.set_xlabel("Time Delta")
+        ax.set_title(f"{s.name} - {ev['EventName']} ({ev['EventDate'].year})")
+        fig.suptitle(f"Fastest: {top['LapTime']} ({top['Driver']})")
 
         f = utils.plot_to_file(fig, f"plt_fastlap-{s.name}-{ev['EventDate'].year}-{ev['RoundNumber']}")
         await MessageTarget(ctx).send(file=f)
@@ -197,15 +199,17 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         points = np.array([pos["X"], pos["Y"]]).T.reshape(-1, 1, 2)
         segs = np.concatenate([points[:-1], points[1:]], axis=1)
         speed = car["Speed"]
+        del lap, car
 
-        fig, ax = plt.subplots(sharex=True, sharey=True, figsize=(12, 6.75), dpi=DPI)
+        fig = Figure(figsize=(12, 6.75), dpi=DPI, layout="constrained")
+        ax = fig.subplots(sharex=True, sharey=True)
         ax.axis("off")
 
         # Create the track outline from pos coordinates
         ax.plot(pos["X"], pos["Y"], color="black", linestyle="-", linewidth=12, zorder=0)
 
         # Map the segments to colours
-        norm = plt.Normalize(speed.min(), speed.max())
+        norm = Normalize(speed.min(), speed.max())
         lc = LineCollection(segs, cmap="plasma", norm=norm, linestyle="-", linewidth=5)
         lc.set_array(speed)
 
@@ -215,7 +219,7 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         # Add legend
         cax = fig.add_axes([0.25, 0.05, 0.5, 0.025])
         fig.colorbar(speed_line, cax=cax, location="bottom", label="Speed (km/h)")
-        plt.suptitle(f"{drv_id} Track Speed - {ev['EventDate'].year} {ev['EventName']}", size=16)
+        fig.suptitle(f"{drv_id} Track Speed - {ev['EventDate'].year} {ev['EventName']}", size=16)
 
         f = utils.plot_to_file(fig, f"plot_trackspeed-{drv_id}-{ev['EventDate'].year}-{ev['RoundNumber']}")
         await MessageTarget(ctx).send(file=f)
@@ -233,32 +237,37 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         ##
 
         ev = await stats.to_event(year, round)
-        yr, rd = ev["EventDate"].year, ev["RoundNumber"]
+        yr, rd, nm = ev["EventDate"].year, ev["RoundNumber"], ev["EventName"]
         s = await stats.load_session(ev, session, laps=True, telemetry=True)
         drivers = [driver1, driver2]
         drv_ids = [utils.find_driver(d, await ergast.get_all_drivers(yr, rd))["code"]
                    for d in drivers if d is not None]
 
+        laps = s.laps.pick_accurate()
+
         # Get data for each driver
         data: dict[str, pd.DataFrame] = {}
+        laptimes = []
         for d in drv_ids:
-            laps = s.laps.pick_accurate()
             if d not in laps["Driver"].values:
                 raise MissingDataError(f"No lap data for driver {d}")
-            tel = laps.pick_driver(d).pick_fastest().get_car_data().add_distance()
-            data[d] = tel
+            lap = laps.pick_driver(d).pick_fastest()
+            laptimes.append(lap["LapTime"])
+            data[d] = lap.get_car_data().add_distance()
+            del lap
 
         # Determine the x-axis position for each sector divider
         # based on the percentage of each sector time from the total lap time
-        fl = s.laps.pick_fastest()
+        fl = laps.pick_fastest()
         max_dis = data[drv_ids[0]]["Distance"].max()
         s1_dis = max_dis * (fl["Sector1Time"] / fl["LapTime"])
         s2_dis = s1_dis + max_dis * (fl["Sector2Time"] / fl["LapTime"])
+        del fl
 
         # Plot 6 subplots for each telemetry graph
-        fig, ax = plt.subplots(6, figsize=(18, 14), dpi=DPI,
-                               gridspec_kw={"height_ratios": [3, 2, 1, 1, 2, 1]},
-                               sharex=True)
+        fig = Figure(figsize=(18, 14), dpi=DPI, layout="constrained")
+        ax = fig.subplots(6, gridspec_kw={"height_ratios": [3, 2, 1, 1, 2, 1]},
+                          sharex=True)
 
         for d, t in data.items():
             c = utils.get_driver_or_team_color(d, s)
@@ -325,12 +334,6 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         ax[5].set_yticklabels([])
         ax[5].set_xlabel("Distance (m)")
 
-        laptimes = [
-            utils.format_timedelta(
-                s.laps.pick_driver(d).pick_fastest()["LapTime"]
-            ) for d in drv_ids
-        ]
-
         # Show sector dividers
         for a in ax:
             a.yaxis.label.set_fontsize(13)
@@ -338,12 +341,12 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
             a.vlines([s1_dis, s2_dis], ylim[0], ylim[1], colors="w",
                      linestyles="dotted", linewidth=1, zorder=0, alpha=0.5)
 
-        ax[0].set_title(
-            f"Lap Comparison - {session} - {yr} {ev['EventName']}\n" +
-            f"{drv_ids[0]}: {laptimes[0]}" +
-            (f" | {drv_ids[1]}: {laptimes[1]}" if len(laptimes) > 1 else "")
-        ).set_fontsize(18)
-        plt.tight_layout()
+        ax[0].set_title("".join([
+            f"Lap Comparison - {session} - {yr} {nm}",
+            f"\n{drv_ids[0]}: {utils.format_timedelta(laptimes[0])}",
+            (f" | {drv_ids[1]}: {utils.format_timedelta(laptimes[1])}"
+             if len(laptimes) > 1 else "")
+        ])).set_fontsize(18)
 
         # File
         f = utils.plot_to_file(fig, f"plt_telemetry_{yr}_{rd}_{'-'.join(drv_ids)}")
@@ -381,6 +384,7 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
             ["mSector", "Driver"]
         ].rename(columns={"Driver": "Fastest"})
         telemetry = telemetry.merge(fastest, on=["mSector"]).sort_values(by=["Distance"])
+        del mTimes, fastest
 
         # Assign fastest driver to int for plotting
         telemetry.loc[telemetry["Fastest"] == drivers[0], ["Fastest"]] = 1
@@ -393,7 +397,8 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         segs = np.concatenate([points[:-1], points[1:]], axis=1)
         fastest_drivers = telemetry["Fastest"].astype(float).values
 
-        fig, ax = plt.subplots(sharex=True, sharey=True, figsize=(10, 8), dpi=DPI)
+        fig = Figure(figsize=(10, 8), dpi=DPI, layout="constrained")
+        ax = fig.subplots(sharex=True, sharey=True)
         ax.axis("off")
 
         # Create track outline from pos
@@ -402,6 +407,8 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
                 linestyle="-",
                 linewidth=12,
                 zorder=0)
+
+        del telemetry
 
         # Map minisector segments to fastest driver colour
         cmap = ListedColormap([utils.get_driver_or_team_color(d, s) for d in drivers])
@@ -412,11 +419,11 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         sectors = ax.add_collection(lc)
 
         # Add colorbar legend
-        cax = fig.add_axes([0.15, 0.1, 0.1, 0.02])
+        cax = fig.add_axes([0.05, 0.05, 0.1, 0.02])
         fig.colorbar(sectors, cax=cax, location="bottom", ticks=[1.5, 2.5]).set_ticklabels([d for d in drivers])
         ax.set_title(
             f"Fastest Sectors | {drivers[0]} v {drivers[1]}\n{yr} {ev['EventName']} - {session}"
-        ).set_fontsize(12)
+        ).set_fontsize(14)
 
         f = utils.plot_to_file(fig, f"plt_trksectors_{yr}_{rd}")
         await MessageTarget(ctx).send(file=f, content="**Fastest Sector Comparison**")
@@ -432,23 +439,24 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         s = await stats.load_session(ev, "R")
         data = stats.pos_change(s)
 
-        fig, ax = plt.subplots(figsize=(10, 5), dpi=DPI)
+        fig = Figure(figsize=(10, 5), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot()
 
         # Plot pos diff for each driver
         for row in data.itertuples():
-            bar = plt.bar(
+            bar = ax.bar(
                 x=row.Driver,
                 height=row.Diff,
                 color="firebrick" if int(row.Diff) < 0 else "forestgreen",
                 label=row.Diff,
             )
             ax.bar_label(bar, label_type="center")
+        del data
 
-        plt.title(f"Pos Gain/Loss - {ev['EventName']} ({(ev['EventDate'].year)})")
-        plt.xlabel("Driver")
-        plt.ylabel("Change")
+        ax.set_title(f"Pos Gain/Loss - {ev['EventName']} ({(ev['EventDate'].year)})")
+        ax.set_xlabel("Driver")
+        ax.set_ylabel("Change")
         ax.grid(True, alpha=0.1)
-        plt.tight_layout()
 
         f = utils.plot_to_file(fig, f"plot_poschange-{ev['EventDate'].year}-{ev['RoundNumber']}")
         await MessageTarget(ctx).send(file=f)
@@ -472,12 +480,13 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         # Get tyre colours
         clrs = [fastf1.plotting.COMPOUND_COLORS[i] for i in sorted_count.index]
 
-        fig, ax = plt.subplots(figsize=(8, 6), dpi=DPI, subplot_kw={"aspect": "equal"})
+        fig = Figure(figsize=(8, 6), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot(aspect="equal")
+
         ax.pie(sorted_percent, colors=clrs, autopct="%1.1f%%", textprops={"color": "black"})
 
-        plt.legend(sorted_count.index)
-        plt.title(f"Tyre Distribution - {session}\n{ev['EventName']} ({ev['EventDate'].year})")
-        plt.tight_layout()
+        ax.legend(sorted_count.index)
+        ax.set_title(f"Tyre Distribution - {session}\n{ev['EventName']} ({ev['EventDate'].year})")
 
         f = utils.plot_to_file(fig, f"plt_tyrechoice-{ev['RoundNumber']}-{ev['EventDate'].year}")
         await MessageTarget(ctx).send(file=f)
@@ -499,8 +508,10 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         # Group laps using only quicklaps to exclude pitstops and slow laps
         laps = s.laps.pick_drivers(drivers).pick_accurate()
         times = laps.loc[:, ["Driver", "LapNumber", "LapTime"]].groupby("Driver")
+        del laps
 
-        fig, ax = plt.subplots(figsize=(8, 5), dpi=DPI)
+        fig = Figure(figsize=(8, 5), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot()
 
         for d, t in times:
             ax.plot(
@@ -509,12 +520,13 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
                 label=d,
                 color=utils.get_driver_or_team_color(d, s)
             )
+        del times
 
-        plt.title(f"Lap Difference -\n{ev['EventName']} ({ev['EventDate'].year})")
-        plt.xlabel("Lap")
-        plt.ylabel("Time")
+        ax.set_title(f"Lap Difference -\n{ev['EventName']} ({ev['EventDate'].year})")
+        ax.set_xlabel("Lap")
+        ax.set_ylabel("Time")
         ax.grid(True, alpha=0.1)
-        plt.legend()
+        ax.legend()
 
         f = utils.plot_to_file(
             fig, f"plt_comparelaps-{drivers[0]}{drivers[1]}-{ev['EventDate'].year}-{ev['RoundNumber']}")
@@ -539,7 +551,8 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         labels = [s.get_driver(d)["Abbreviation"] for d in point_finishers]
         compounds = laps["Compound"].unique()
 
-        fig, ax = plt.subplots(figsize=(10, 5), dpi=DPI)
+        fig = Figure(figsize=(10, 5), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot()
 
         sns.violinplot(data=laps,
                        x=laps.index,
@@ -557,9 +570,10 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
                       palette=[fastf1.plotting.COMPOUND_COLORS[c] for c in compounds],
                       linewidth=0,
                       size=5)
+        del laps
 
         ax.set_xlabel("Driver (Point Finishers)")
-        plt.title(f"Lap Distribution - {ev['EventName']} ({ev['EventDate'].year})")
+        ax.set_title(f"Lap Distribution - {ev['EventName']} ({ev['EventDate'].year})")
         sns.despine(left=True, right=True)
 
         f = utils.plot_to_file(fig, f"plt_lapdist-{ev['EventDate'].year}-{ev['RoundNumber']}")
@@ -577,7 +591,8 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
         data = stats.tyre_performance(s)
         compounds = data["Compound"].unique()
 
-        fig, ax = plt.subplots(figsize=(10, 5), dpi=DPI)
+        fig = Figure(figsize=(10, 5), dpi=DPI, layout="constrained")
+        ax = fig.add_subplot()
 
         for cmp in compounds:
             mask = data["Compound"] == cmp
@@ -587,12 +602,12 @@ class Plot(commands.Cog, guild_ids=Config().guilds):
                 label=cmp,
                 color=fastf1.plotting.COMPOUND_COLORS[cmp]
             )
+        del data
 
-        plt.xlabel("Tyre Life")
-        plt.ylabel("Lap Time (s)")
-        plt.title(f"Tyre Performance - {ev['EventDate'].year} {ev['EventName']}")
-        plt.legend()
-        plt.tight_layout()
+        ax.set_xlabel("Tyre Life")
+        ax.set_ylabel("Lap Time (s)")
+        ax.set_title(f"Tyre Performance - {ev['EventDate'].year} {ev['EventName']}")
+        ax.legend()
 
         f = utils.plot_to_file(fig, f"plt_tyreperf-{ev['EventDate'].year}-{ev['RoundNumber']}")
         await MessageTarget(ctx).send(file=f)

--- a/f1/commands.py
+++ b/f1/commands.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 import asyncio
 import re
@@ -39,7 +40,7 @@ async def on_message(message: Message):
 
 
 def handle_command(ctx: commands.Context | ApplicationContext):
-    logger.info(f"Command: /{ctx.command} in {ctx.channel} by {ctx.user}")
+    logger.info(f"Command: /{ctx.command} in {ctx.guild.name} {ctx.channel} by {ctx.user}")
 
 
 async def handle_errors(ctx: commands.Context | ApplicationContext, err):
@@ -47,7 +48,9 @@ async def handle_errors(ctx: commands.Context | ApplicationContext, err):
     if ctx.response.is_done():
         return
 
-    logger.error(f"Command failed: /{ctx.command}\n {err}")
+    logger.error(f"Command failed: /{ctx.command} in {ctx.guild.name} {ctx.channel} by {ctx.user}")
+    logger.error(f"Selected Options: {ctx.selected_options}")
+    logger.error(f"Reason: {err}")
     target = MessageTarget(ctx)
 
     # Catch TimeoutError
@@ -89,6 +92,11 @@ async def on_application_command(ctx: ApplicationContext):
 @bot.event
 async def on_command_completion(ctx: commands.Context):
     await ctx.message.add_reaction(u'🏁')
+
+
+@bot.event
+async def on_application_command_completion(ctx: ApplicationContext):
+    gc.collect()
 
 
 @bot.event

--- a/f1/commands.py
+++ b/f1/commands.py
@@ -7,6 +7,7 @@ from discord import ApplicationContext, Message
 from discord.errors import ApplicationCommandInvokeError
 from discord.activity import Activity, ActivityType
 from discord.ext import commands
+from matplotlib import pyplot as plt
 
 from f1.target import MessageTarget
 from f1.config import Config
@@ -44,6 +45,10 @@ def handle_command(ctx: commands.Context | ApplicationContext):
 
 
 async def handle_errors(ctx: commands.Context | ApplicationContext, err):
+    # Force cleanup
+    plt.close("all")
+    gc.collect()
+
     # Command or Cog handler already responded
     if ctx.response.is_done():
         return

--- a/f1/utils.py
+++ b/f1/utils.py
@@ -4,13 +4,14 @@ from datetime import date, datetime
 from io import BytesIO
 from operator import itemgetter
 
+import matplotlib.pyplot as plt
 import pandas as pd
 from discord import ApplicationContext, Colour, File
 from discord.ext import commands
+from fastf1 import plotting
+from fastf1.core import Session
 from matplotlib.figure import Figure
 from tabulate import tabulate
-from fastf1.core import Session
-from fastf1 import plotting
 
 from f1.api.fetch import fetch
 from f1.config import CACHE_DIR
@@ -312,6 +313,12 @@ def plot_to_file(fig: Figure, name: str):
         fig.savefig(buffer, format="png", bbox_inches="tight")
         buffer.seek(0)
         file = File(buffer, filename=f"{name}.png")
+        # Clean up memory
+        buffer.close()
+        fig.clear()
+        plt.close("all")
+        del fig
+
         return file
 
 

--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,0 +1,1 @@
+backend: agg

--- a/poetry.lock
+++ b/poetry.lock
@@ -1212,6 +1212,21 @@ files = [
 ]
 
 [[package]]
+name = "memory-profiler"
+version = "0.61.0"
+description = "A module for monitoring memory usage of a python program"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "memory_profiler-0.61.0-py3-none-any.whl", hash = "sha256:400348e61031e3942ad4d4109d18753b2fb08c2f6fb8290671c5513a34182d84"},
+    {file = "memory_profiler-0.61.0.tar.gz", hash = "sha256:4e5b73d7864a1d1292fb76a03e82a3e78ef934d06828a698d9dada76da2067b0"},
+]
+
+[package.dependencies]
+psutil = "*"
+
+[[package]]
 name = "multidict"
 version = "6.0.4"
 description = "multidict implementation"
@@ -2391,4 +2406,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "189a7a0d1ebc404e8d89f98d8d67e9b2b0208bea765a0e5ebbc3f3f9a2a5417a"
+content-hash = "52b944b764ce6fdd6e6cc2ed299907e6147fa36077136dc0b735c0258892355d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ plottable = "^0.1.5"
 flake8 = "^6.0.0"
 autopep8 = "^2.0.2"
 ipykernel = "^6.22.0"
+memory-profiler = "^0.61.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Addresses the biggest blocks of memory not being freed up after command execution and plot figures lingering with additional blocks being allocated over time. 

- Replace `pyplot.subplots` interface with `Figure` instances
- Replace `plt.tight_layout` with `layout="constrained"` parameter
- Force clear any lingering plots with `plt.close()` when saving
- Delete large intermediate dataframes where they are no longer needed
- Force `gc.collect()` after command completion

Memory usage now only spikes during data processing but gets freed up after execution. 

![](https://i.imgur.com/dzInpM6.png)
 
